### PR TITLE
Explicitly request Python 2 in shebang.

### DIFF
--- a/get_hmac_and_key.py
+++ b/get_hmac_and_key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import requests # pip install requests
 import binascii

--- a/read_minimed_next24.py
+++ b/read_minimed_next24.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import hid # pip install hidapi - Platform independant
 import astm # pip install astm

--- a/read_pcap.py
+++ b/read_pcap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import binascii


### PR DESCRIPTION
Avoids issues on systems where Python 3 is default.