### PR TITLE
BUGFIX: make history events print on python 3 style print

### DIFF
--- a/pump_history_parser.py
+++ b/pump_history_parser.py
@@ -219,6 +219,9 @@ class NGPHistoryEvent:
     
     def __str__(self):
         return '{0} {1:x} {2}'.format(self.__class__.__name__, self.eventType, self.timestamp)
+
+    def __repr__(self):
+        return str(self)
     
     def allNestedEvents(self):
         yield self.eventInstance()

--- a/read_minimed_next24.py
+++ b/read_minimed_next24.py
@@ -1264,14 +1264,15 @@ def pumpDownload(mt):
     print ("Battery remaining: {0}%").format( status.batteryLevelPercentage )
     
     print ("Getting Pump history info")
-    historyInfo = mt.getPumpHistoryInfo(datetime.datetime(2017, 8, 23), datetime.datetime.max, HISTORY_DATA_TYPE.PUMP_DATA)
+    start_date = datetime.datetime.now() - datetime.timedelta(days=1)
+    historyInfo = mt.getPumpHistoryInfo(start_date, datetime.datetime.max, HISTORY_DATA_TYPE.PUMP_DATA)
     # print (binascii.hexlify( historyInfo.responsePayload,  ))
     print (" Pump Start: {0}").format(historyInfo.datetimeStart)
     print (" Pump End: {0}").format(historyInfo.datetimeEnd);
     print (" Pump Size: {0}").format(historyInfo.historySize);
     
     print ("Getting Pump history")
-    history_pages = mt.getPumpHistory(historyInfo.historySize, datetime.datetime(2016, 1, 1), datetime.datetime.max, HISTORY_DATA_TYPE.PUMP_DATA)
+    history_pages = mt.getPumpHistory(historyInfo.historySize, start_date, datetime.datetime.max, HISTORY_DATA_TYPE.PUMP_DATA)
 
     # Uncomment to save events for testing without Pump (use: tests/process_saved_history.py)
     #with open('history_data.dat', 'wb') as output:
@@ -1284,14 +1285,14 @@ def pumpDownload(mt):
     print ("# End Pump events")
 
     print ("Getting sensor history info")
-    sensHistoryInfo = mt.getPumpHistoryInfo(datetime.datetime(2017, 8, 23), datetime.datetime.max, HISTORY_DATA_TYPE.SENSOR_DATA)
+    sensHistoryInfo = mt.getPumpHistoryInfo(start_date, datetime.datetime.max, HISTORY_DATA_TYPE.SENSOR_DATA)
     # print (binascii.hexlify( historyInfo.responsePayload,  ))
     print (" Sensor Start: {0}").format(sensHistoryInfo.datetimeStart)
     print (" Sensor End: {0}").format(sensHistoryInfo.datetimeEnd);
     print (" Sensor Size: {0}").format(sensHistoryInfo.historySize);
     
     print ("Getting Sensor history")
-    sensor_history_pages = mt.getPumpHistory(sensHistoryInfo.historySize, datetime.datetime(2016, 1, 1), datetime.datetime.max, HISTORY_DATA_TYPE.SENSOR_DATA)
+    sensor_history_pages = mt.getPumpHistory(sensHistoryInfo.historySize, start_date, datetime.datetime.max, HISTORY_DATA_TYPE.SENSOR_DATA)
 
     # Uncomment to save events for testing without Pump (use: tests/process_saved_history.py)
     #with open('sensor_history_data.dat', 'wb') as output:


### PR DESCRIPTION
MINOR CHANGE: change hardcoded dates for history download start to one variable defaulting 1d