### PR TITLE
Specify CareLink server from command line

### DIFF
--- a/get_hmac_and_key.py
+++ b/get_hmac_and_key.py
@@ -18,9 +18,10 @@ logging.disable( logging.CRITICAL )
 from read_minimed_next24 import Config, Medtronic600SeriesDriver
 
 class CareLinkRequest( javaobj.JavaObjectMarshaller ):
-    def __init__( self ):
-        self.object_stream = io.StringIO()
+    def __init__( self, minimedAddressRoot ):
+        self.object_stream = io.BytesIO()
         self._writeStreamHeader()
+        self.minimedAddressRoot = minimedAddressRoot
 
 class CareLinkKeyRequest( CareLinkRequest ):
     def buildRequest( self, serial ):
@@ -29,7 +30,7 @@ class CareLinkKeyRequest( CareLinkRequest ):
         return self.object_stream.getvalue()
 
     def decodeResponse( self, data ):
-        decoder = javaobj.JavaObjectUnmarshaller( io.StringIO( data ) )
+        decoder = javaobj.JavaObjectUnmarshaller( io.BytesIO(data) )
         int1 = struct.unpack( '>I', decoder.readObject() )[0]
         # If int1 is 16, then we have valid data in the following object. If it's 0,
         # then no data follows
@@ -47,7 +48,7 @@ class CareLinkKeyRequest( CareLinkRequest ):
     def post( self, longSerial, session ):
         data = self.buildRequest( longSerial )
 
-        response = session.post( 'https://carelink.minimed.eu/patient/main/../secure/SnapshotServer/',
+        response = session.post( 'https://%s/patient/main/../secure/SnapshotServer/' % self.minimedAddressRoot,
             headers = { 'Content-Type': 'application/octet-stream' },
             data = data
         )
@@ -63,7 +64,7 @@ class CareLinkHMACRequest( CareLinkRequest ):
         return self.object_stream.getvalue()
 
     def decodeResponse( self, data ):
-        decoder = javaobj.JavaObjectUnmarshaller( io.StringIO( data ) )
+        decoder = javaobj.JavaObjectUnmarshaller( io.BytesIO(data ) )
         hmacArray = decoder.readObject()
         hmac = ''.join('{:02x}'.format( x & 0xff ) for x in reversed(hmacArray) )
         return hmac
@@ -71,7 +72,7 @@ class CareLinkHMACRequest( CareLinkRequest ):
     def post( self, serial, session ):
         data = self.buildRequest( serial )
 
-        response = session.post( 'https://carelink.minimed.eu/patient/main/../secure/SnapshotServer/',
+        response = session.post( 'https://%s/patient/main/../secure/SnapshotServer/' % self.minimedAddressRoot,
             headers = { 'Content-Type': 'application/octet-stream' },
             data = data
         )
@@ -83,12 +84,12 @@ def getHmac( serial ):
     digest = hashlib.sha256(serial + paddingKey).hexdigest()
     return "".join(reversed([digest[i:i+2] for i in range(0, len(digest), 2)]))
 
-def getHmacAndKey( config, serial, longSerial, session ):
-    #request = CareLinkHMACRequest()
+def getHmacAndKey( config, serial, longSerial, session, addressRoot ):
+    #request = CareLinkHMACRequest(addressRoot)
     #hmac = request.post( serial, session )
     hmac = getHmac( serial )
 
-    request = CareLinkKeyRequest()
+    request = CareLinkKeyRequest(addressRoot)
     ( int1, key, count ) = request.post( longSerial, session )
 
     config.hmac = hmac
@@ -100,6 +101,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument( 'username', help='The CareLink username with which to retrieve the HMAC and key' )
     parser.add_argument( '--db', action='store_true', help='Process all entries in the config database, rather than the connected USB stick' )
+    parser.add_argument( '-a', '--addressRoot', type=str, default='carelink.minimed.eu', help='The domain name of which CareLink reagion you wish to connect to.  Defaults to the EU reagion')
     args = parser.parse_args()
 
     password = getpass.getpass( 'Enter the password for the CareLink user {0}: '.format( args.username ) )
@@ -117,7 +119,7 @@ if __name__ == '__main__':
     }
 
     with requests.Session() as session:
-        session.post( 'https://carelink.minimed.eu/patient/j_security_check', data = payload )
+        session.post( 'https://%s/patient/j_security_check' % args.addressRoot, data = payload )
 
         if args.db:
             for row in c.fetchall():
@@ -144,4 +146,4 @@ if __name__ == '__main__':
             serial = re.sub( r"\d+-", "", longSerial )
             config = Config( longSerial )
 
-            getHmacAndKey( config, serial, longSerial, session )
+            getHmacAndKey( config, serial, longSerial, session, args.addressRoot )


### PR DESCRIPTION
Added ability to specify which CareLink server to use from the command line.  This is useful if you aren't in the EU region as the request would succeed but return a binary blob that `javaobj` couldn't decode causing the program to fail with less than helpful diagnostics.  The program still defaults to the EU server.  `io.StringIO` has been replaced with `io.BytesIO` which removes the need to cast to a `unicode` object.